### PR TITLE
feat(cli): add --help output with available animations, usage example…

### DIFF
--- a/bin/flossum.js
+++ b/bin/flossum.js
@@ -40,6 +40,7 @@ const text = args.slice(1).join(' ');
       await flossum.progressBar();
       break;
     case '--help':
+    case '-h':
     default:
       console.log(`
 🌸 Flossum CLI — Terminal Animations
@@ -55,8 +56,21 @@ Usage:
   flossum reverse "Goodbye!"
   flossum progress
 
+Available Animations:
+  typeOut (alias: type)
+  wave
+  glitch
+  scramble
+  spinner
+  pulse (alias: colorPulse)
+  rainbow
+  reverse (alias: reverseType)
+  progress (alias: progressBar)
+
 Options:
-  --help        Show this help message
+  --help, -h    Show this help message
+
+GitHub: https://github.com/pushkarsinghh/flossum
 `);
   }
 })();


### PR DESCRIPTION
## ✨ Description

This PR adds a comprehensive `--help` output for the Flossum CLI, addressing **[#4](https://github.com/pushkarsinghh/flossum/issues/4)**.

### 📋 Features
- Lists **all available animations** and their aliases in a clear section
- Shows **example usage** for each animation
- Adds a **link to the GitHub repository**
- Supports both `--help` and `-h` flags

---

### ✅ Checklist
- [x] All animations and aliases are listed
- [x] Example usage is provided
- [x] GitHub repo link is included
- [x] Both `--help` and `-h` flags are supported

closes #4