### PR TITLE
feat: add dots loading animations [#17]

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 * 🅰️ ASCII art text rendering (`asciiArt`)
 * ⚡ Flashing text effect (`flash`)
 * ✂️ Type-delete effect (`typeDelete`)
+* ⏳ Dots loading animation (`dots`)
 
 ## 📦 Installation
 
@@ -45,6 +46,12 @@ await flossum.playFrames([
   '[     ]', '[=    ]', '[==   ]', '[===  ]', '[==== ]', '[=====]', '[ ====]', '[  ===]', '[   ==]', '[    =]', '[     ]',
 ], { interval: 3000, delay: 90, repeat: 3});
 
+await flossum.dots("Loading", {
+  cycles: 5,
+  interval: 300,
+  char: ".",
+  maxDots: 3
+});
 ```
 
 
@@ -62,6 +69,7 @@ flossum spinner "Please wait..."
 flossum progressBar
 flossum flash "⚡ Flashing now!"
 flossum typeDelete "Deleting now..."
+flossum dots "Loading"
 ```
 
 ```bash

--- a/bin/flossum.js
+++ b/bin/flossum.js
@@ -45,6 +45,9 @@ const text = args.slice(1).join(' ');
     case 'typeDelete':
       await flossum.typeDelete(text);
       break;
+    case 'dots':
+      await flossum.dots(text);
+      break;
     case '--help':
     case '-h':
     default:
@@ -63,6 +66,7 @@ Usage:
   flossum progress
   flossum flash "Flashing text"
   flossum typeDelete "Erasing this..."
+  flossum dots "Loading..."
 
 
 Available Animations:
@@ -77,6 +81,7 @@ Available Animations:
   progress (alias: progressBar)
   flash
   typeDelete
+  dots
 
 Options:
   --help, -h    Show this help message

--- a/examples/demo.js
+++ b/examples/demo.js
@@ -29,4 +29,5 @@ const frames = [
   await flossum.typeOut("🎉 All done! Enjoy coding!", 50);
   await flossum.flash("⚠️ Warning!", {flashes: 6,interval: 150});
   await flossum.typeDelete("👋 Watch this disappear!", { delay: 100,deleteDelay: 80,pause: 1000,repeat: false});
+  await flossum.dots("Loading", { cycles: 5, interval: 300 });
 })();

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ import { spinner } from './lib/simple/spinner.js';
 import { asciiArt } from './lib/effects/asciiArt.js';
 import {flash} from './lib/simple/flash.js';
 import {typeDelete} from "./lib/simple/typeDelete.js";
+import { dots } from './lib/loaders/dots.js';
 const flossum = {
   typeOut,
   spinner,
@@ -23,8 +24,9 @@ const flossum = {
   colorPulse,
   playFrames,
   asciiArt,
-  flash, 
-  typeDelete
+  flash,
+  typeDelete,
+  dots
 };
 
 export { flossum };

--- a/lib/loader/dots.js
+++ b/lib/loader/dots.js
@@ -1,0 +1,22 @@
+import { clearLine, sleep } from '../core/utils.js';
+
+export async function dots(text = '', options = {}) {
+    const {
+        cycles = 5,
+        interval = 300,
+        char = '.',
+        maxDots = 3
+    } = options;
+
+    for (let cycle = 0; cycle < cycles; cycle++) {
+        for (let i = 1; i <= maxDots; i++) {
+            clearLine();
+            const dots = char.repeat(i);
+            process.stdout.write(`${text}${dots}`)
+            await sleep(interval);
+        }
+    }
+
+    clearLine();
+    process.stdout.write(`${text}${char.repeat(maxDots)}\n`)
+}


### PR DESCRIPTION
## Description
Adds a dots loading animation (`.` → `..` → `...`) to the library


## Changes
- Created `lib/loaders/dots.js` with dots loader
- Updated `index.js` to export dots function
- Updated `README.md` with documentation

## Usage
```javascript
await flossum.dots("Loading", {
  cycles: 5,            // number of times the animation repeats
  interval: 300,    // delay in milliseconds between each dot
  char: ".",           // character to display (can be any character like "=")
  maxDots: 5      // maximum number of dots/characters to show before resetting
});
```