### PR TITLE
refactor: switch to commander.js for argument parsing [#10]

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1,0 +1,180 @@
+# Commands
+
+## `typeout`
+Types text character by character
+
+**Options:**
+* `-s, --speed <ms>` — typing speed (default: `50`)
+
+**Example:**
+```bash
+flossum typeout "Hello there" -s 80
+```
+
+---
+
+## `reverse`
+Reveals text from end to start
+
+**Options:**
+* `-s, --speed <ms>` — typing speed (default: `50`)
+
+**Example:**
+```bash
+flossum reverse "Goodbye" -s 60
+```
+
+---
+
+## `wave`
+Animated wave effect with colors
+
+**Options:**
+* `-d, --duration <ms>` — animation duration (default: `2000`)
+
+**Example:**
+```bash
+flossum wave "Wavy text" -d 3000
+```
+
+---
+
+## `glitch`
+Glitchy text animation
+
+**Options:**
+* `-d, --duration <ms>` — animation duration (default: `2000`)
+* `-s, --steps <number>` — number of glitch steps (default: `10`)
+
+**Example:**
+```bash
+flossum glitch "Error" -d 1500 -s 15
+```
+
+---
+
+## `scramble`
+Scrambles characters into place
+
+**Options:**
+* `-d, --duration <ms>` — animation duration (default: `1000`)
+
+**Example:**
+```bash
+flossum scramble "Decrypting..." -d 2000
+```
+
+---
+
+## `rainbow`
+Cycles through rainbow colors
+
+**Options:**
+* `-d, --duration <ms>` — animation duration (default: `2000`)
+
+**Example:**
+```bash
+flossum rainbow "Colorful text" -d 3000
+```
+
+---
+
+## `pulse`
+Color pulsing animation
+
+**Options:**
+* `-d, --duration <ms>` — animation duration (default: `2000`)
+
+**Example:**
+```bash
+flossum pulse "Pulsing text" -d 2500
+```
+
+---
+
+## `spinner`
+Displays a loading spinner
+
+**Options:**
+* `-d, --duration <ms>` — spinner duration (default: `2000`)
+
+**Example:**
+```bash
+flossum spinner "Loading..." -d 5000
+```
+
+---
+
+## `dots`
+Loading animation with dots
+
+**Options:**
+* `-c, --cycles <number>` — number of cycles (default: `5`)
+* `-i, --interval <ms>` — interval between dots (default: `300`)
+* `--char <string>` — dot character (default: `.`)
+* `-m, --max-dots <number>` — maximum dots (default: `3`)
+
+**Example:**
+```bash
+flossum dots "Processing" -c 10 -i 200 -m 5
+```
+
+---
+
+## `progress`
+Displays a progress bar
+
+**Options:**
+* `-w, --width <number>` — bar width (default: `30`)
+* `-d, --duration <ms>` — animation duration (default: `2000`)
+* `-c, --char <string>` — progress character (default: `█`)
+
+**Example:**
+```bash
+flossum progress -w 50 -d 3000 -c "="
+```
+
+---
+
+## `flash`
+Flashes text on and off
+
+**Options:**
+* `-f, --flashes <number>` — number of flashes (default: `6`)
+* `-i, --interval <ms>` — interval between flashes (default: `150`)
+
+**Example:**
+```bash
+flossum flash "Alert" -f 10 -i 100
+```
+
+---
+
+## `typeDelete`
+Types text then deletes it
+
+**Options:**
+* `-d, --delay <ms>` — typing delay (default: `100`)
+* `--delete-delay <ms>` — deletion delay (default: `100`)
+* `-p, --pause <ms>` — pause before deleting (default: `1000`)
+* `-r, --repeat` — repeat infinitely (default: `false`)
+
+**Example:**
+```bash
+flossum typeDelete "Temporary text" -d 50 -p 2000
+flossum typeDelete "Forever" -r
+```
+
+---
+
+## Help
+
+Show all commands:
+```bash
+flossum --help
+```
+
+Show help for specific command:
+```bash
+flossum typeout --help
+```

--- a/README.md
+++ b/README.md
@@ -56,27 +56,7 @@ await flossum.dots("Loading", {
 
 
 ## ⚙️ CLI Usage
-
-```bash
-flossum typeOut "Hello World"
-flossum reverseType "Backwards magic"
-flossum wave "Wavy Text"
-flossum colorPulse "Pulse!"
-flossum glitch "Glitch!"
-flossum scramble "Secret..."
-flossum rainbow "🌈"
-flossum spinner "Please wait..."
-flossum progressBar
-flossum flash "⚡ Flashing now!"
-flossum typeDelete "Deleting now..."
-flossum dots "Loading"
-```
-
-```bash
-flossum --help
-```
-
-> Lists all available animations and usage instructions.
+For detailed command usage, see [COMMAND.md](COMMANDS.md)
 
 ## 🎬 Demo
 

--- a/bin/flossum.js
+++ b/bin/flossum.js
@@ -1,92 +1,168 @@
 #!/usr/bin/env node
 
-import flossum from '../index.js';
+import { Command } from "commander";
+import flossum from "../index.js";
+import pkg from "../package.json" with { type: "json" };
 
-const args = process.argv.slice(2);
-const command = args[0];
-const text = args.slice(1).join(' ');
+const program = new Command();
 
-(async () => {
-  switch (command) {
-    case 'type':
-    case 'typeOut':
-      await flossum.typeOut(text);
-      break;
-    case 'wave':
-      await flossum.wave(text);
-      break;
-    case 'glitch':
-      await flossum.glitch(text);
-      break;
-    case 'scramble':
-      await flossum.scramble(text);
-      break;
-    case 'spinner':
-      await flossum.spinner(text);
-      break;
-    case 'pulse':
-    case 'colorPulse':
-      await flossum.colorPulse(text);
-      break;
-    case 'rainbow':
-      await flossum.rainbow(text);
-      break;
-    case 'reverse':
-    case 'reverseType':
-      await flossum.reverseType(text);
-      break;
-    case 'progress':
-    case 'progressBar':
-      await flossum.progressBar();
-      break;
-    case 'flash':
-      await flossum.flash(text);
-      break;
-    case 'typeDelete':
-      await flossum.typeDelete(text);
-      break;
-    case 'dots':
-      await flossum.dots(text);
-      break;
-    case '--help':
-    case '-h':
-    default:
-      console.log(`
-🌸 Flossum CLI — Terminal Animations
+program.name("flossum").description("Terminal Animations").version(pkg.version);
 
-Usage:
-  flossum typeOut "Hello World"
-  flossum wave "Wavy text"
-  flossum glitch "Glitchy..."
-  flossum scramble "Scrambling..."
-  flossum spinner "Loading..."
-  flossum pulse "Color Pulse"
-  flossum rainbow "Taste the rainbow"
-  flossum reverse "Goodbye!"
-  flossum progress
-  flossum flash "Flashing text"
-  flossum typeDelete "Erasing this..."
-  flossum dots "Loading..."
+program
+  .command("typeout <text...>")
+  .description("Type out text character by character")
+  .option("-s, --speed <ms>", "typing speed in milliseconds", "50")
+  .action(async (txt, options) => {
+    await flossum.typeOut(txt.join(" "), ensureNumber(options.speed, "speed"));
+  });
 
+program
+  .command("wave <text...>")
+  .description("Animated wave effect with colors")
+  .option("-d, --duration <ms>", "animation duration in milliseconds", "2000")
+  .action((txt, options) => {
+    flossum.wave(txt.join(" "), {
+      duration: ensureNumber(options.duration, "duration"),
+    });
+  });
 
-Available Animations:
-  typeOut (alias: type)
-  wave
-  glitch
-  scramble
-  spinner
-  pulse (alias: colorPulse)
-  rainbow
-  reverse (alias: reverseType)
-  progress (alias: progressBar)
-  flash
-  typeDelete
-  dots
+program
+  .command("glitch <text...>")
+  .description("Glitchy text animation")
+  .option("-d, --duration <ms>", "animation duration in milliseconds", "2000")
+  .option("-s, --steps <number>", "number of glich steps", "10")
+  .action((txt, options) => {
+    flossum.glitch(txt.join(" "), {
+      duration: ensureNumber(options.duration, "duration"),
+      steps: ensureNumber(options.steps, "steps"),
+    });
+  });
 
-Options:
-  --help, -h    Show this help message
+program
+  .command("scramble <text...>")
+  .description("Scramble text into place")
+  .option("-d, --duration <ms>", "animation duration in milliseconds", "1000")
+  .action((txt, options) => {
+    flossum.scramble(txt.join(" "), {
+      duration: ensureNumber(options.duration, "duration"),
+    });
+  });
 
-GitHub: https://github.com/pushkarsinghh/flossum
-`);
+program
+  .command("spinner [text...]")
+  .description("Show a loading spinner")
+  .option("-d, --duration <ms>", "spinner duration in milliseconds", "2000")
+  .action(async (txt, options) => {
+    await flossum.spinner(
+      txt.join(" "),
+      ensureNumber(options.duration, "duration"),
+    );
+  });
+
+program
+  .command("pulse <text...>")
+  .description("Color pulsing animation")
+  .option("-d, --duration <ms>", "animation duration in milliseconds", "2000")
+  .action((txt, options) => {
+    flossum.colorPulse(
+      txt.join(" "),
+      ensureNumber(options.duration, "duration"),
+    );
+  });
+
+program
+  .command("rainbow <text...>")
+  .description("Rainbow color animation")
+  .option("-d, --duration <ms>", "animation duration in milliseconds", "2000")
+  .action(async (txt, options) => {
+    await flossum.rainbow(txt.join(" "), {
+      duration: ensureNumber(options.duration, "duration"),
+    });
+  });
+
+program
+  .command("reverse <text...>")
+  .description("Type text in reverse (reveal from end)")
+  .option("-s, --speed <ms>", "typing speed in millisecondsl", "50")
+  .action(async (txt, options) => {
+    await flossum.reverseType(
+      txt.join(" "),
+      ensureNumber(options.speed, "speed"),
+    );
+  });
+
+program
+  .command("progress")
+  .description("Show a progress bar")
+  .option("-w, --width <number>", "progress bar width", "30")
+  .option("-d, --duration <ms>", "animation duration in seconds", "2000")
+  .option("-c, --char <string>", "progress character", "█")
+  .action(async (options) => {
+    await flossum.progressBar({
+      width: ensureNumber(options.width, "width"),
+      duration: ensureNumber(options.duration, "duration"),
+      char: options.char,
+    });
+  });
+
+program
+  .command("flash <text...>")
+  .description("Flash text on and off")
+  .option("-f, --flashes <number>", "number of flashes", "6")
+  .option(
+    "-i, --interval <ms>",
+    "interval between flashles in milliseconds",
+    150,
+  )
+  .action(async (txt, options) => {
+    await flossum.flash(txt.join(" "), {
+      flashes: ensureNumber(options.flashes, "flashes"),
+      interval: ensureNumber(options.interval, "interval"),
+    });
+  });
+
+program
+  .command("typeDelete <text...>")
+  .description("Type text then delete it")
+  .option("-d, --delay <ms>", "typing delay in milliseconds", "100")
+  .option("--delete-delay <ms>", "deletion delay in milliseconds", "100")
+  .option("-p, --pause <ms>", "pause before deleting in milliseconds", "1000")
+  .option("-r, --repeat", "repeat animation indefinitely", false)
+  .action(async (txt, options) => {
+    await flossum.typeDelete(txt.join(" "), {
+      delay: ensureNumber(options.delay, "delay"),
+      deleteDelay: ensureNumber(options.deleteDelay, "delete-delay"),
+      pause: ensureNumber(options.pause, "pause"),
+      repeat: options.repeat,
+    });
+  });
+
+program
+  .command("dots [text...]")
+  .description("Loading animation with dots")
+  .option("-c, --cycles <number>", "number of cycles", "5")
+  .option(
+    "-i, --interval <number>",
+    "interval between dots in milliseconds",
+    "300",
+  )
+  .option("--char <string>", "dot characher", ".")
+  .option("-m, --max-dots <number>", "maximum number of dots", "3")
+  .action(async (txt, options) => {
+    await flossum.dots(txt.join(" "), {
+      cycles: ensureNumber(options.cycles, "cycles"),
+      interval: ensureNumber(options.interval, "interval"),
+      char: options.char,
+      maxDots: ensureNumber(options.maxDots, "max-dots"),
+    });
+  });
+
+program.parse(process.argv);
+
+function ensureNumber(strVal, placeholder) {
+  const val = parseInt(strVal, 10);
+  if (isNaN(val)) {
+    program.error(`error: ${placeholder} must be a number`);
   }
-})();
+  return val;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,21 @@
 {
   "name": "flossum",
-  "version": "1.0.5",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flossum",
-      "version": "1.0.5",
+      "version": "1.0.8",
       "license": "ISC",
       "dependencies": {
         "cfonts": "^3.3.0",
-        "chalk": "^5.4.1"
+        "chalk": "^5.4.1",
+        "commander": "^14.0.2",
+        "flossum": "^1.0.5"
       },
       "bin": {
         "flossum": "bin/flossum.js"
-      },
-      "exports": {
-    ".": "./index.js"
       }
     },
     "node_modules/cfonts": {
@@ -46,6 +45,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/commander": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
+      "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
@@ -55,6 +63,20 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/flossum": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/flossum/-/flossum-1.0.8.tgz",
+      "integrity": "sha512-/vg1cmjkF0S4pCKRuedwUFvy3ZPdDUPb1MnAiChSW8WhiRv8o1OYg+OoYUFwwY/UQQI9L8Day+cibKU0IFtyDw==",
+      "license": "ISC",
+      "dependencies": {
+        "cfonts": "^3.3.0",
+        "chalk": "^5.4.1",
+        "flossum": "^1.0.5"
+      },
+      "bin": {
+        "flossum": "bin/flossum.js"
       }
     },
     "node_modules/function-bind": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "cfonts": "^3.3.0",
     "chalk": "^5.4.1",
+    "commander": "^14.0.2",
     "flossum": "^1.0.5"
   }
 }


### PR DESCRIPTION
## Description
Refactored the CLI to use Commander.js for proper argument parsing, enabling users to pass animation options via flags

## Changes
- Added Commander.js for CLI argument parsing
- Support for animation options: `--duration`, `--speed`, `--steps`, etc
- Created `COMMANDS.md` with comprehensive usage guide

## Example Usage
```bash
flossum typeout "Hello" --speed 100
flossum glitch "Error" --duration 2000 --steps 15
flossum progress --width 50 --duration 3000
```